### PR TITLE
Create docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  bgkalendar:
+    image: bgkalendar/bgkalendar
+    ports:
+      - "${PORT_NUMBER:-8387}:80"
+    stdin_open: true
+    tty: true
+    privileged: true
+    restart: always


### PR DESCRIPTION
add bgkalendar service to Docker Compose file  

- Define bgkalendar service with image `bgkalendar/bgkalendar`
- Expose container port 80 to host port by default 8387 but can be optional if export PORT_NUMBER environment variable
- Enable interactive mode (`stdin_open`, `tty`) for the service
- Grant privileged mode and set the service to always restart

Command to start 
docker compose up -d
Command to stop 
docker compose down